### PR TITLE
ci: Add makefile step

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         ref: ${{ github.event.inputs.localRef }}
         fetch-depth: 0
+    - name: Verify make command
+      shell: bash
+      run: make
     - name: Setup SSH Keys
       uses: webfactory/ssh-agent@v0.7.0
       with:


### PR DESCRIPTION
Adding an extra step to the release workflow to ensure that the default makefile command builds as expected.