### PR TITLE
fix: Add SWIFT_PACKAGE_NAME to support package access level

### DIFF
--- a/Configuration/Apollo/Apollo-Target-Framework.xcconfig
+++ b/Configuration/Apollo/Apollo-Target-Framework.xcconfig
@@ -1,3 +1,4 @@
 #include "../Shared/Workspace-Universal-Framework.xcconfig"
 
 INFOPLIST_FILE = Sources/Apollo/Info.plist
+SWIFT_PACKAGE_NAME = Apollo

--- a/Configuration/Apollo/ApolloWebSocket-Target-Framework.xcconfig
+++ b/Configuration/Apollo/ApolloWebSocket-Target-Framework.xcconfig
@@ -1,3 +1,4 @@
 #include "../Shared/Workspace-Universal-Framework.xcconfig"
 
 INFOPLIST_FILE = Sources/ApolloWebSocket/Info.plist
+SWIFT_PACKAGE_NAME = Apollo


### PR DESCRIPTION
## Summary

The 2.1.0 release introduced `SubscriptionStateStorage` and a `package init` on `SubscriptionStream` using Swift's `package` access level to allow cross-module access between the `Apollo` and `ApolloWebSocket` targets within the same Swift package.

When building with xcodebuild (as this xcframework project does), the Swift compiler requires a `-package-name` flag (or the `SWIFT_PACKAGE_NAME` build setting) whenever `package` access level is used. Without it, the compiler cannot resolve `package`-access declarations and fails with:

```
error: the package access level used on 'SubscriptionStateStorage' requires a package name; set it with the compiler flag -package-name
error: cannot find 'SubscriptionStateStorage' in scope
```

## Fix

Added `SWIFT_PACKAGE_NAME = Apollo` to the xcconfig files for both the `Apollo` and `ApolloWebSocket` targets. Both targets must share the same package name so that `ApolloWebSocket` can access `package`-level types from `Apollo`.

## Files changed

- `Configuration/Apollo/Apollo-Target-Framework.xcconfig`
- `Configuration/Apollo/ApolloWebSocket-Target-Framework.xcconfig`